### PR TITLE
add file that shows how a theorem with an "AND" might look

### DIFF
--- a/mockup.html
+++ b/mockup.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Math Visualization Experiment</title>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/cytoscape/3.26.0/cytoscape.min.js" integrity="sha512-rOsRHy2O7kykGotH99Bi0+LyynL6rfQpaMiKOwYa1K1jYAFksJUwXE1gE6Relgo88g6lQ/uf8NaWeyzi1T53Zg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    </head>
+    <body>
+        <p>This is a hardcoded mockup of what <a href="https://topology.pi-base.org/theorems/T000306">T306</a> might look like</p>
+        <div id="cy" style="width:100%;height:500px;display:block;border:1px solid black"></div>
+        <script>
+  cytoscape({
+
+    container: document.getElementById('cy'), // container to render in
+
+    elements: [ // list of graph elements to start with
+      {
+        data: { id: "P000051", label: "P000051: Scattered", color: "blue", parent: "and" },
+        position: {x:200, y:100}
+      },
+      {
+        data: { id: "P000137", label: "xP000137: Empty", color: "red", parent: "and" },
+        position: {x:200, y:0}
+      },
+      {
+        data: { id: "P000139", label: "P000139: Has an isolated point", color: "blue" },
+        position: {x:500, y:50}
+      },
+      {
+        data: { id: "and", label: "", color: "light gray" }
+      },
+      {
+        data: { id: 'arrow', source: "and", target: "P000139" }
+      }
+    ],
+
+    style: [ // the stylesheet for the graph
+      {
+        selector: 'node',
+        style: {
+          'background-color': 'data(color)',
+          'label': 'data(label)'
+        }
+      },
+      {
+        selector: ':parent',
+        style: {
+          'background-color': '#ccc',
+          'border-color': '#bbb',
+        }
+      },
+
+      {
+        selector: 'edge',
+        style: {
+          'width': 3,
+          'line-color': '#ccc',
+          'target-arrow-color': '#ccc',
+          'target-arrow-shape': 'triangle',
+          'curve-style': 'bezier'
+        }
+      },
+    ],
+
+    layout: {
+      name: 'preset',
+      rows: 1
+    }
+
+    });
+        </script>
+    </body>
+</html>


### PR DESCRIPTION
You can merge this in (it's a separate file). It produces the output I've screenshotted below:

![image](https://github.com/clontz-fall-2023/math-visualization-experiments/assets/1559632/a9eec695-e10f-4f6b-b61b-066e86e68c44)

I did all of this by hand - you'll need to figure out how to read in a `theorem`, and inject its values into the right places. (I don't expect this before we meet next.)